### PR TITLE
Feat: Hydration mismatch fix on persistent state

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -15,8 +15,15 @@ export class Observable<TState> {
   }
 
   private readonly eventName = `${Observable.stateIndex++}-global-state-change`
+  private readonly _initializationValue: TState
 
-  constructor(private _value: TState) {}
+  constructor(private _value: TState) {
+    this._initializationValue = _value
+  }
+
+  get initializationValue() {
+    return this._initializationValue
+  }
 
   get value() {
     return this._value

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -16,9 +16,11 @@ export class Observable<TState> {
 
   private readonly eventName = `${Observable.stateIndex++}-global-state-change`
   private readonly _initializationValue: TState
+  private _value: TState
 
-  constructor(private _value: TState) {
-    this._initializationValue = _value
+  constructor(value: TState) {
+    this._initializationValue = value
+    this._value = value
   }
 
   get initializationValue() {

--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -34,7 +34,7 @@ export const createGlobalState = <TState>(
     state$.next(updater(state$.value, state))
   }
 
-  const useGlobalState = createHook(state$, setGlobalState, initialState)
+  const useGlobalState = createHook(state$, setGlobalState)
 
   const useReadOnlyState = createReadOnlyHook(state$, state => state)
 

--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -34,7 +34,7 @@ export const createGlobalState = <TState>(
     state$.next(updater(state$.value, state))
   }
 
-  const useGlobalState = createHook(state$, setGlobalState)
+  const useGlobalState = createHook(state$, setGlobalState, initialState)
 
   const useReadOnlyState = createReadOnlyHook(state$, state => state)
 

--- a/src/createHook.ts
+++ b/src/createHook.ts
@@ -1,6 +1,7 @@
-import { SetStateAction, useEffect, useState } from "react"
+import { SetStateAction } from "react"
 
 import { Observable } from "./Observable"
+import { createReadOnlyHook } from "./createReadOnlyHook"
 import { SetStateOptions } from "./types"
 
 export function createHook<TState>(
@@ -10,28 +11,10 @@ export function createHook<TState>(
     options?: SetStateOptions
   ) => void
 ) {
+  const useReadOnlyState = createReadOnlyHook(state$, state => state);
+
   return () => {
-    const [state, setState] = useState<TState>(state$.initializationValue)
-
-    useEffect(() => {
-      /**
-       * We use the `initialState` value and only update the state after mounting the component.
-       * This helps us keep a consistent and predictable state between server and client rendering
-       *  consequently avoiding a possible hydration mismatch.
-       */
-      const stateValueAfterMount = state$.value
-
-      if (state !== stateValueAfterMount) {
-        setState(stateValueAfterMount)
-      }
-
-      const subscription = state$.subscribe(setState)
-
-      return () => subscription.unsubscribe()
-
-      // we don't want to rerun on state change
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    const state = useReadOnlyState()
 
     return [state, setGlobalState] as const
   }

--- a/src/createHook.ts
+++ b/src/createHook.ts
@@ -8,18 +8,17 @@ export function createHook<TState>(
   setGlobalState: (
     state: SetStateAction<TState>,
     options?: SetStateOptions
-  ) => void
+  ) => void,
+  initialState: TState
 ) {
   return () => {
-    const [state, setState] = useState(state$.value)
+    const [state, setState] = useState<TState>(initialState)
 
     useEffect(() => {
       /**
-       * Update the current state after mounting the component:
-       * It is possible that the initial state is empty before mounting
-       * if that's the case we return an empty state which is not updated
-       * through the subscription during the first mounting if setGlobalState is called
-       * the reason for that is we only subscribe to the state$ if the component is mounted
+       * We use the `initialState` value and only update the state after mounting the component.
+       * This helps us keep a consistent and predictable state between server and client rendering
+       *  consequently avoiding a possible hydration mismatch.
        */
       const stateValueAfterMount = state$.value
 

--- a/src/createHook.ts
+++ b/src/createHook.ts
@@ -8,11 +8,10 @@ export function createHook<TState>(
   setGlobalState: (
     state: SetStateAction<TState>,
     options?: SetStateOptions
-  ) => void,
-  initialState: TState
+  ) => void
 ) {
   return () => {
-    const [state, setState] = useState<TState>(initialState)
+    const [state, setState] = useState<TState>(state$.initializationValue)
 
     useEffect(() => {
       /**


### PR DESCRIPTION
## Summary
This PR fixes [the hydration mismatch when using persistent state](https://github.com/foobaragency/foo-state/issues/104).

### Details
On this PR:
- We fixed the bug in the `createReadOnlyHook` function;
- We then refactored the `createHook` function and reused the `createReadOnlyHook` function inside, which brought the fix with it;
- Finally, as a pre-requisite to this fix, we extended the `Observable` class to save the value used during initialisation.

**It is important to note that**:
- The bug can still happen if the user introduces it. The user could still use a different value in the client and the server, for example, sending a value if there is an available value in `localhost` and a different one if it is not. This would create a mismatch, but this is expected and should be resolved by the user.
- The `initializationValue` could show an "updated value" for non-primitives rather than the initial object set during initialization... but this is consistent and makes sense because, if for example initialised with an array, the initialisation value was not the content of the array but the array's reference. We could deep copy the initial value but I believe it is better not pre-optimizing until it is needed and get feedback from its usage before even changing it. Also, it is some sort of "magic" since it no longer saves the initial value of objects(being it their reference), but rather its content. Finally, this is an internal object of the library, so any library consumer should, most of the time, not think about this.

## How to test

These changes are not easily tested with unit tests because:
- The test cannot be run by changing the browser environment since the environment can not be changed mid-test while the tests are running. We have to choose to set the testing environment to either `jsdom` or `node`. Therefore, we cannot compare the server side rendered vs the client side render on unit tests.
- We tried and avoided hoisting the import of `Person` by using `require`, we did this to avoid running the `createGlobalState` before setting the `localstorage`.
- We are also able to set the `window` to `undefined` mid-test, but that doesn't really help because the check of the window is done once on `createGlobalState` which does not run again.
- The state is global and therefore shared to the component no matter how/where it is rendered.
- We could mock the return of `createGlobalState` to have full control on what to return and when, but that would not make much sense because that is what we want to test... 🙁 

Therefore, we decided to test in "production", well, kind of 😅 The idea was basically test in an app that consumes this library, but we did not want to fo through the whole deployment cycle just to test, so, instead we:
- worked on the changes needed,
- then we built the `foo-state` library by running `yarn build`, 
- once it was built, we went to the `foo-state` folder in the `node_modules` of a project that uses this library and replaced the `lib` and `src` folders with the ones generated in the build from the previous step,
- finally, we ran the project that uses this library and make sure there is no hydration mismatch when using persistent state.