### PR TITLE
Chore: Change dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: friday
-      time: "08:00"
+      interval: "monthly"
+      time: "10:00"
       timezone: Europe/Berlin
     labels:
       - "dependencies"


### PR DESCRIPTION
### Context
Change dependabot schedule interval to reduce the amount of pipeline executions in Github / Vercel and to not extrapolate too much the executions.

The idea would be to have the dependencies update every 15 days, however Github doesn't offer this option, only: daily, weekly and monthly. More info: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval